### PR TITLE
add AzureAD, initContainer, S3 onprem

### DIFF
--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Set postgresql URL
 {{- if .Values.postgresql.enabled -}}
 {{- printf "postgres://outline:%s@%s-postgresql:%d/outline" .Values.postgresql.password (include "outline.fullname" .) (int .Values.postgresql.port) -}}
 {{- else -}}
-{{- .Values.postgresqlUrl | required "A value must be entered for postgresqlUrl" | quote -}}
+{{- .Values.outline.postgresqlUrl | required "A value must be entered for postgresqlUrl" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -28,6 +28,26 @@ spec:
       serviceAccountName: {{ include "outline.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: {{ .Chart.Name }}-init
+          command:
+            - yarn
+            - sequelize:migrate
+            - --env=production-ssl-disabled
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DEBUG
+              value: {{ .Values.outline.debug | default "" | quote }}
+            - name: PGSSLMODE
+              value: {{ .Values.outline.postgresqlSslMode | default "enable" | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ include "outline.fullname" . }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -41,12 +61,18 @@ spec:
               value: {{ .Values.outline.aws.s3.region | default "" | quote }}
             - name: AWS_S3_ACL
               value: {{ .Values.outline.aws.s3.acl | default "" | quote }}
+            - name: AWS_S3_FORCE_PATH_STYLE
+              value: {{ .Values.outline.aws.s3.forcePathStyle | default "false" | quote }}
             - name: AWS_S3_UPLOAD_BUCKET_NAME
               value: {{ .Values.outline.aws.s3.bucket | default "" | quote }}
             - name: AWS_S3_UPLOAD_BUCKET_URL
               value: {{ .Values.outline.aws.s3.endpoint | default "" | quote }}
             - name: AWS_S3_UPLOAD_MAX_SIZE
               value: {{ .Values.outline.aws.s3.maxSize | default "" | quote }}
+            - name: AZURE_CLIENT_ID
+              value: {{ .Values.outline.auth.azure.clientId | default "" | quote }}
+            - name: AZURE_RESOURCE_APP_ID
+              value: {{ .Values.outline.auth.azure.resourceAppId | default "" | quote }}
             - name: DEBUG
               value: {{ .Values.outline.debug | default "" | quote }}
             - name: ENABLE_UPDATES
@@ -59,6 +85,8 @@ spec:
               value: {{ .Values.outline.googleAnalyticsId | default "" | quote }}
             - name: GOOGLE_CLIENT_ID
               value: {{ .Values.outline.auth.google.clientId | default "" | quote }}
+            - name: PGSSLMODE
+              value: {{ .Values.outline.postgresqlSslMode | default "enable" | quote }}
             - name: PORT
               value: {{ .Values.outline.containerPort | default 3000 | quote }}
             - name: SLACK_APP_ID

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "outline.labels" . | nindent 4 }}
 data:
   AWS_SECRET_ACCESS_KEY: {{ .Values.outline.aws.secret | b64enc | quote }}
-  DATABASE_URL: {{ .Values.outline.postgresqlUrl | b64enc | quote }}
+  DATABASE_URL: {{ include "outline.postgresqlUrl" . | b64enc }}
   AZURE_CLIENT_SECRET: {{ .Values.outline.auth.azure.clientSecret | b64enc | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.outline.auth.google.clientSecret | b64enc | quote }}
   REDIS_URL: {{ include "outline.redisUrl" . | b64enc | quote }}

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "outline.labels" . | nindent 4 }}
 data:
   AWS_SECRET_ACCESS_KEY: {{ .Values.outline.aws.secret | b64enc | quote }}
-  DATABASE_URL: {{ include "outline.postgresqlUrl" . | b64enc | quote }}
+  DATABASE_URL: {{ .Values.outline.postgresqlUrl | b64enc | quote }}
+  AZURE_CLIENT_SECRET: {{ .Values.outline.auth.azure.clientSecret | b64enc | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.outline.auth.google.clientSecret | b64enc | quote }}
   REDIS_URL: {{ include "outline.redisUrl" . | b64enc | quote }}
   SECRET_KEY: {{ .Values.outline.secrets.key | b64enc | quote }}

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -37,7 +37,7 @@ outline:
   containerPort: 3000
   debug: "cache,presenters,events,emails,logistics,mailer,utils,multiplayer,server,services"
   enableUpdates: true
-  externalUrl: "https://foobar.com/outline"
+  externalUrl: "https://foobar.com"
   forceHttps: "false"
   googleAnalyticsId: ""
   notifications:

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -11,6 +11,10 @@ fullnameOverride: ""
 
 outline:
   auth:
+    azure:
+      clientId: ""
+      clientSecret: ""
+      resourceAppId: ""
     google:
       allowedDomains:
         - example.com
@@ -27,13 +31,14 @@ outline:
       acl: private    # Set to public-read to allow public access
       bucket: ""
       endpoint: ""
+      forcePathStyle: "false"
       maxSize: 26214400
       region: ""
   containerPort: 3000
-  debug: "sql,cache,presenters,events,logistics,emails,mailer"
+  debug: "cache,presenters,events,emails,logistics,mailer,utils,multiplayer,server,services"
   enableUpdates: true
   externalUrl: "https://foobar.com/outline"
-  forceHttps: true
+  forceHttps: "false"
   googleAnalyticsId: ""
   notifications:
     slack:
@@ -41,6 +46,7 @@ outline:
       messageActions: true
       verificationToken: ""
   postgresqlUrl: ""   # This is mandatory only if embedded postgresql is disabled
+  postgresqlSslMode: enable
   redisUrl: ""        # This is mandatory only if embedded redis is disabled
   secrets:
     key: foobar


### PR DESCRIPTION
- support for Microsoft AzureAD Auth
- initContainer to perform DB migrates
- adds aws.s3.forcePathStyle for Amazon alternatives
- adds postgresqlSslMode option to disable TLS 
- changes forceHttps default to "false" (affects Liveness/Readiness checks where 301 redirect is issued)